### PR TITLE
Remove deprecated layout options

### DIFF
--- a/UraniumControlIssue/MainPage.xaml
+++ b/UraniumControlIssue/MainPage.xaml
@@ -5,7 +5,7 @@
              xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
              x:Class="UraniumControlIssue.MainPage">
 
-    <VerticalStackLayout Spacing="10" WidthRequest="{OnIdiom Default=-1,Desktop=400}" Padding="20">
+    <VerticalStackLayout Spacing="10" WidthRequest="{OnIdiom Default=-1,Desktop=400}" Padding="20" VerticalOptions="Center">
         <material:TextField Title="Username"
                       Icon="{FontImageSource FontFamily=MaterialRegular,
                                              Glyph={x:Static m:MaterialRegular.Email}}"
@@ -30,7 +30,7 @@
 
     <!--IF YOU STILL CONTINUE WITH THE GRID, YOU CAN USE THIS CODE BELOW 👇 -->
 
-    <!--<Grid RowDefinitions="Auto,Auto,Auto" WidthRequest="{OnIdiom Default=-1, Desktop=400}" Padding="20" RowSpacing="10">
+    <!--<Grid RowDefinitions="Auto,Auto,Auto" WidthRequest="{OnIdiom Default=-1, Desktop=400}" Padding="20" RowSpacing="10" VerticalOptions="Center">
      <material:TextField Title="Username" Grid.Row="0"
                          Icon="{FontImageSource FontFamily=MaterialRegular,
                                                 Glyph={x:Static m:MaterialRegular.Email}}"

--- a/UraniumControlIssue/MainPage.xaml
+++ b/UraniumControlIssue/MainPage.xaml
@@ -5,44 +5,50 @@
              xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
              x:Class="UraniumControlIssue.MainPage">
 
-    <Grid RowDefinitions="Auto, Auto, Auto"
-          RowSpacing="10"
-          VerticalOptions="CenterAndExpand">
+    <VerticalStackLayout Spacing="10" WidthRequest="{OnIdiom Default=-1,Desktop=400}" Padding="20">
+        <material:TextField Title="Username"
+                      Icon="{FontImageSource FontFamily=MaterialRegular,
+                                             Glyph={x:Static m:MaterialRegular.Email}}"
+                      AllowClear="True"
+                      Keyboard="Text"/>
 
-        <material:TextField Grid.Row="0"
-                            Title="Username"
-                            Icon="{FontImageSource FontFamily=MaterialRegular,
-                                                   Glyph={x:Static m:MaterialRegular.Email}}"
-                            HorizontalOptions="{OnIdiom Desktop=CenterAndExpand,
-                                                        Default=FillAndExpand}"
-                            VerticalOptions="CenterAndExpand"
-                            WidthRequest="{OnIdiom Desktop=450,
-                                                   Default=-1}"
-                            BorderThickness="2"
-                            AllowClear="True"
-                            Keyboard="Text" />
+        <material:TextField Title="Username"
+                      Icon="{FontImageSource FontFamily=MaterialRegular,
+                                             Glyph={x:Static m:MaterialRegular.Password}}"
+                      AllowClear="True"
+                      Keyboard="Text">
 
-        <material:TextField Grid.Row="1"
-                            Title="Password"
-                            Icon="{FontImageSource FontFamily=MaterialRegular,
-                                                   Glyph={x:Static m:MaterialRegular.Password}}"
-                            HorizontalOptions="{OnIdiom Desktop=CenterAndExpand,
-                                                        Default=FillAndExpand}"
-                            VerticalOptions="CenterAndExpand"
-                            WidthRequest="{OnIdiom Desktop=450,
-                                                   Default=-1}"
-                            BorderThickness="2"
-                            IsPassword="True"
-                            Keyboard="Text">
             <material:TextField.Attachments>
                 <material:TextFieldPasswordShowHideAttachment />
             </material:TextField.Attachments>
         </material:TextField>
 
-        <Button Grid.Row="2"
-                HorizontalOptions="CenterAndExpand"
-                VerticalOptions="CenterAndExpand"
-                Text="Login"
-                WidthRequest="70" />
-    </Grid>
+        <Button Text="Login"
+          WidthRequest="70" />
+
+    </VerticalStackLayout>
+
+    <!--IF YOU STILL CONTINUE WITH THE GRID, YOU CAN USE THIS CODE BELOW 👇 -->
+
+    <!--<Grid RowDefinitions="Auto,Auto,Auto" WidthRequest="{OnIdiom Default=-1, Desktop=400}" Padding="20" RowSpacing="10">
+     <material:TextField Title="Username" Grid.Row="0"
+                         Icon="{FontImageSource FontFamily=MaterialRegular,
+                                                Glyph={x:Static m:MaterialRegular.Email}}"
+                         AllowClear="True"
+                         Keyboard="Text"/>
+
+     <material:TextField Title="Username" Grid.Row="1"
+                         Icon="{FontImageSource FontFamily=MaterialRegular,
+                                                Glyph={x:Static m:MaterialRegular.Password}}"
+                         AllowClear="True"
+                         Keyboard="Text">
+
+         <material:TextField.Attachments>
+             <material:TextFieldPasswordShowHideAttachment />
+         </material:TextField.Attachments>
+     </material:TextField>
+
+     <Button Text="Login" Grid.Row="2"
+             WidthRequest="70" />
+ </Grid>-->
 </ContentPage>


### PR DESCRIPTION

`EndAndExpand`, `CenterAndExpand`, `StartAndExpand`, and `FillAndExpand` are deprecated and when you use TextField with them or inside a layout that one of the deprecated layout options used, it can't render itself properly. I don't plan to support those deprecated layout options, I suggest not to use deprecated layout options in the new projects

https://github.com/dotnet/maui/discussions/7346#discussioncomment-2794122


Official documentation:
https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.layoutoptions.centerandexpand?view=net-maui-7.0

---

In this PR, I just suggest 2 different designs for the same result, my primary suggestion is using `VerticalStacklayout` but I presented a `Grid` usage in the PR, you can continue with one of the approach